### PR TITLE
Correct ESP32 QT Py; add HUZZAH32

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Adafruit Allocated Creation IDs for Adafruit boards. Creator ID: `0x0000_239a`
 
 ## `0x0032_xxxx` - ESP32 dev boards
 *  `0x0032_0001` [Adafruit Feather ESP32 V2](https://www.adafruit.com/product/5400)
+*  `0x0032_0002` [Adafruit Feather HUZZAH32](https://www.adafruit.com/product/3405)
+*  `0x0032_0003` [Adafruit QT Py ESP32 Pico](https://www.adafruit.com/product/5395)
 
 ## `0x00C3_xxxx` - ESP32-C3 dev boards
 *  `0x00C3_0001` [Adafruit QT Py ESP32-C3](https://www.adafruit.com/product/5405)
-*  `0x00C3_0002` [Adafruit QT Py ESP32 PICO](https://www.adafruit.com/product/5395)


### PR DESCRIPTION
@tannewt I missed in the previous review that you were adding the QT Py ESP32 Pico as a C3 board. Fixed that and added HUZZAH32, which I am working on. I can work on both of these.